### PR TITLE
Added checking of some array indexes because of errors thrown on PHP 7

### DIFF
--- a/src/game_example/db/configs/example.json
+++ b/src/game_example/db/configs/example.json
@@ -18,5 +18,16 @@
         "deployment": {
             "testdeploy": "testdeploy"
         }
+    },
+    {
+   "l3.digitalyouthnetwork.org": {
+        "client_id" : "l3test",
+        "auth_login_url" : "https://qa.cityoflearning.me/lti-auth",
+        "auth_token_url" : "http://evanston.col-engine-qa.com/api/v1/lti_tool_providers/1/auth.json",
+        "key_set_url" : "https://qa.cityoflearning.me/packages/l3lti/assets/jwks.json",
+        "private_key_file" : "/private.key",
+        "deployment" : {
+            "1234" : "1234"
+        }
     }
 }

--- a/src/game_example/game.php
+++ b/src/game_example/game.php
@@ -38,8 +38,19 @@ if ($launch->is_deep_link_launch()) {
 </div>
 <link href="https://fonts.googleapis.com/css?family=Gugi" rel="stylesheet">
 <script>
+
+    <?php
+    $launch_data = $launch->get_launch_data();
+    $difficulty = 'normal';
+    if (array_key_exists('https://purl.imsglobal.org/spec/lti/claim/custom', $launch_data)) {
+        if (array_key_exists('difficulty', $launch_data['https://purl.imsglobal.org/spec/lti/claim/custom'])) {
+            $difficulty = $launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']['difficulty'];
+        }
+        
+    }
+    ?>
     // Set game difficulty if it has been set in deep linking
-    var curr_diff = "<?= $launch->get_launch_data()['https://purl.imsglobal.org/spec/lti/claim/custom']['difficulty'] ?: 'normal'; ?>";
+    var curr_diff = "<?= $difficulty ?>";
     var curr_user_name = "<?= $launch->get_launch_data()['name']; ?>";
     var launch_id = "<?= $launch->get_launch_id(); ?>";
 </script>

--- a/src/lti/lti.php
+++ b/src/lti/lti.php
@@ -2,5 +2,10 @@
 include_once("lti_oidc_login.php");
 include_once("lti_message_launch.php");
 include_once("database.php");
-define("TOOL_HOST", ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?: $_SERVER['REQUEST_SCHEME']) . '://' . $_SERVER['HTTP_HOST']);
+if(array_key_exists('HTTP_X_FORWARDED_PROTO', $_SERVER)) {
+  define("TOOL_HOST", ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?: $_SERVER['REQUEST_SCHEME']) . '://' . $_SERVER['HTTP_HOST']);
+} else {
+  define("TOOL_HOST", $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST']);
+}
+
 ?>


### PR DESCRIPTION
lti base class ensures that HTTP_X_FORWARDED_PROTO index exists before using it. Note: In PHP 7.0 on nginx it was throwing issues. game.php ensure the difficulty exists in the custom launch attributes before using it