### PR TITLE
Fix scores and results url to work in moodle

### DIFF
--- a/src/game_example/api/score.php
+++ b/src/game_example/api/score.php
@@ -19,7 +19,8 @@ $score = LTI\LTI_Grade::new()
 $score_lineitem = LTI\LTI_Lineitem::new()
     ->set_tag('score')
     ->set_score_maximum(100)
-    ->set_label('Score');
+    ->set_label('Score')
+    ->set_resource_id($launch->get_launch_data()['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id']);
 $grades->put_grade($score, $score_lineitem);
 
 
@@ -33,7 +34,8 @@ $time = LTI\LTI_Grade::new()
 $time_lineitem = LTI\LTI_Lineitem::new()
     ->set_tag('time')
     ->set_score_maximum(999)
-    ->set_label('Time Taken');
+    ->set_label('Time Taken')
+    ->set_resource_id('time'.$launch->get_launch_data()['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id']);
 $grades->put_grade($time, $time_lineitem);
 echo '{"success" : true}';
 ?>

--- a/src/game_example/api/scoreboard.php
+++ b/src/game_example/api/scoreboard.php
@@ -15,13 +15,15 @@ $ags = $launch->get_ags();
 $score_lineitem = LTI\LTI_Lineitem::new()
     ->set_tag('score')
     ->set_score_maximum(100)
-    ->set_label('Score');
+    ->set_label('Score')
+    ->set_resource_id($launch->get_launch_data()['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id']);;
 $scores = $ags->get_grades($score_lineitem);
 
 $time_lineitem = LTI\LTI_Lineitem::new()
     ->set_tag('time')
     ->set_score_maximum(999)
-    ->set_label('Time Taken');
+    ->set_label('Time Taken')
+    ->set_resource_id('time'.$launch->get_launch_data()['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id']);
 $times = $ags->get_grades($time_lineitem);
 
 $members = $launch->get_nrps()->get_members();

--- a/src/game_example/db/example_database.php
+++ b/src/game_example/db/example_database.php
@@ -4,7 +4,7 @@ session_start();
 use \IMSGlobal\LTI;
 
 $_SESSION['iss'] = [];
-$reg_configs = array_diff(scandir(__DIR__ . '/configs'), array('..', '.'));
+$reg_configs = array_diff(scandir(__DIR__ . '/configs'), array('..', '.', '.DS_Store'));
 foreach ($reg_configs as $key => $reg_config) {
     $_SESSION['iss'] = array_merge($_SESSION['iss'], json_decode(file_get_contents(__DIR__ . "/configs/$reg_config"), true));
 }

--- a/src/lti/lti_assignments_grades_service.php
+++ b/src/lti/lti_assignments_grades_service.php
@@ -30,7 +30,9 @@ class LTI_Assignments_Grades_Service {
             $lineitem = $this->find_or_create_lineitem($lineitem);
             $score_url = $lineitem->get_id();
         }
-        $score_url .= '/scores';
+        // Place '/scores' before url params
+        $pos = strpos($score_url, '?');
+        $score_url = substr_replace( $score_url, '/scores', $pos, 0 );
         return $this->service_connector->make_service_request(
             $this->service_data['scope'],
             'POST',
@@ -70,10 +72,13 @@ class LTI_Assignments_Grades_Service {
 
     public function get_grades(LTI_Lineitem $lineitem) {
         $lineitem = $this->find_or_create_lineitem($lineitem);
+        // Place '/results' before url params
+        $pos = strpos($lineitem->get_id(), '?');
+        $results_url = substr_replace( $lineitem->get_id(), '/results', $pos, 0 );
         $scores = $this->service_connector->make_service_request(
             $this->service_data['scope'],
             'GET',
-            $lineitem->get_id() . '/results',
+            $results_url,
             null,
             null,
             'application/vnd.ims.lis.v2.resultcontainer+json'

--- a/src/lti/lti_service_connector.php
+++ b/src/lti/lti_service_connector.php
@@ -31,7 +31,7 @@ class LTI_Service_Connector {
         $client_id = $this->registration->get_client_id();
         $auth_url = $this->registration->get_auth_token_url();
         $jwt_claim = [
-                "iss" => "TODO_CHANGE_ME",
+                "iss" => $client_id,
                 "sub" => $client_id,
                 "aud" => $auth_url,
                 "iat" => time() - 5,


### PR DESCRIPTION
Here is the list of changes made to breakout during the August 2019 LTI bootcamp. The main bug fix being the scores and results URL (bug occurred when testing in Moodle)

- Add .DS_Store to list of files to ignore when running this tool locally on a mac.
- Set resource IDs for line items
- Fix scores and results url
- Add issuer to JWT claim