### PR TITLE
fix(cookie): index not found

### DIFF
--- a/src/lti/Cookie.php
+++ b/src/lti/Cookie.php
@@ -3,6 +3,9 @@ namespace IMSGlobal\LTI;
 
 class Cookie {
     public function get_cookie($name) {
+        if (!isset($_COOKIE[$name])) {
+            return false;
+        }
         return $_COOKIE[$name];
     }
 


### PR DESCRIPTION
sanity check that the cookie exists before fetching it