### PR TITLE
Make new() functions static

### DIFF
--- a/src/lti/LTI_Deep_Link_Resource.php
+++ b/src/lti/LTI_Deep_Link_Resource.php
@@ -10,7 +10,7 @@ class LTI_Deep_Link_Resource {
     private $custom_params = [];
     private $target = 'iframe';
 
-    public function new() {
+    public static function new() {
         return new LTI_Deep_Link_Resource();
     }
 

--- a/src/lti/LTI_Deployment.php
+++ b/src/lti/LTI_Deployment.php
@@ -5,7 +5,7 @@ class LTI_Deployment {
 
     private $deployment_id;
 
-    public function new() {
+    public static function new() {
         return new LTI_Deployment();
     }
 


### PR DESCRIPTION
Changed `LTI_Deep_Link_Resource::new()` and `LTI_Deployment::new()` to be declared static. Calling non-static methods statically is deprecated and will throw an error in future PHP versions. 

This shouldn't break most existing code, since the documentation calls for them to be used statically. Also other `::new()` functions are static.