### PR TITLE
Make random strings more random

### DIFF
--- a/src/lti/LTI_Deep_Link.php
+++ b/src/lti/LTI_Deep_Link.php
@@ -20,7 +20,7 @@ class LTI_Deep_Link {
             "aud" => [$this->registration->get_issuer()],
             "exp" => time() + 600,
             "iat" => time(),
-            "nonce" => uniqid("nonce"),
+            "nonce" => 'nonce' . hash('sha256', random_bytes(64)),
             "https://purl.imsglobal.org/spec/lti/claim/deployment_id" => $this->deployment_id,
             "https://purl.imsglobal.org/spec/lti/claim/message_type" => "LtiDeepLinkingResponse",
             "https://purl.imsglobal.org/spec/lti/claim/version" => "1.3.0",

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -1,8 +1,8 @@
 <?php
 namespace IMSGlobal\LTI;
 
-use \Firebase\JWT\JWT;
-use \Firebase\JWT\JWK;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 
 JWT::$leeway = 5;
 
@@ -26,7 +26,7 @@ class LTI_Message_Launch {
     function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
         $this->db = $database;
 
-        $this->launch_id = uniqid("lti1p3_launch_");
+        $this->launch_id = uniqid("lti1p3_launch_", true);
 
         if ($cache === null) {
             $cache = new Cache();

--- a/src/lti/LTI_Service_Connector.php
+++ b/src/lti/LTI_Service_Connector.php
@@ -1,8 +1,7 @@
 <?php
 namespace IMSGlobal\LTI;
 
-use \Firebase\JWT\JWT;
-use \Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 
 class LTI_Service_Connector {
     private $registration;
@@ -29,7 +28,7 @@ class LTI_Service_Connector {
                 "aud" => $this->registration->get_auth_server(),
                 "iat" => time() - 5,
                 "exp" => time() + 60,
-                "jti" => uniqid("lti-service-token")
+                "jti" => 'lti-service-token' . hash('sha256', random_bytes(64))
         ];
 
         // Sign the JWT with our private key (given by the platform on registration)


### PR DESCRIPTION
`uniqid()` is generated as a function of system time, so it doesn't work well for generating nonces. It raised some warnings from one of our security inspections.

The [OIDC spec recommends a cryptographically secure hash of a cryptographically secure string](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes), so I used a sha256 hash of 64 bytes generated by `random_bytes()`. I did the same for the `jti` claim in the access token.

I kept `uniqid()` for LTI_Message_Launch IDs, but because it can lead to collisions if called twice with the same system clock (possible with network time resets) I added the `more_entropy` parameter to add more entropy.