### PR TITLE
Dual write cookies to support Chrome 80 samesite update

### DIFF
--- a/src/lti/Cache.php
+++ b/src/lti/Cache.php
@@ -2,26 +2,45 @@
 namespace IMSGlobal\LTI;
 
 class Cache {
+
+    private $cache;
+
     public function get_launch_data($key) {
-        return $_SESSION[$key];
+        $this->load_cache();
+        return $this->cache[$key];
     }
 
     public function cache_launch_data($key, $jwt_body) {
-        $_SESSION[$key] = $jwt_body;
+        $this->cache[$key] = $jwt_body;
+        $this->save_cache();
         return $this;
     }
 
     public function cache_nonce($nonce) {
-        $_SESSION['nonce'][$nonce] = true;
+        $this->cache['nonce'][$nonce] = true;
+        $this->save_cache();
         return $this;
     }
 
     public function check_nonce($nonce) {
-        if (!isset($_SESSION['nonce'][$nonce])) {
+        $this->load_cache();
+        if (!isset($this->cache['nonce'][$nonce])) {
             return false;
         }
-        unset($_SESSION['nonce'][$nonce]);
         return true;
+    }
+
+    private function load_cache() {
+        $cache = file_get_contents(sys_get_temp_dir() . '/lti_cache.txt');
+        if (empty($cache)) {
+            file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', '{}');
+            $this->cache = [];
+        }
+        $this->cache = json_decode($cache, true);
+    }
+
+    private function save_cache() {
+        file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', json_encode($this->cache));
     }
 }
 ?>

--- a/src/lti/Cookie.php
+++ b/src/lti/Cookie.php
@@ -3,14 +3,31 @@ namespace IMSGlobal\LTI;
 
 class Cookie {
     public function get_cookie($name) {
-        if (!isset($_COOKIE[$name])) {
-            return false;
+        if (isset($_COOKIE[$name])) {
+            return $_COOKIE[$name];
         }
-        return $_COOKIE[$name];
+        // Look for backup cookie if same site is not supported by the user's browser.
+        if (isset($_COOKIE["LEGACY_" . $name])) {
+            return $_COOKIE["LEGACY_" . $name];
+        }
+        return false;
     }
 
-    public function set_cookie($name, $value, $exp = 3600) {
-        setcookie($name, $value, time() + $exp);
+    public function set_cookie($name, $value, $exp = 3600, $options = []) {
+        $cookie_options = [
+            'expires' => time() + $exp
+        ];
+
+        // SameSite none and secure will be required for tools to work inside iframes
+        $same_site_options = [
+            'samesite' => 'None',
+            'secure' => true
+        ];
+
+        setcookie($name, $value, array_merge($cookie_options, $same_site_options, $options));
+
+        // Set a second fallback cookie in the event that "SameSite" is not supported
+        setcookie("LEGACY_" . $name, $value, array_merge($cookie_options, $options));
         return $this;
     }
 }

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -62,7 +62,7 @@ class LTI_OIDC_Login {
         // Generate State.
         // Set cookie (short lived)
         $state = str_replace('.', '_', uniqid('state-', true));
-        $this->cookie->set_cookie("lti1p3_$state", $state);
+        $this->cookie->set_cookie("lti1p3_$state", $state, 60);
 
         // Generate Nonce.
         $nonce = uniqid('nonce-', true);


### PR DESCRIPTION
This is to allow for continued function inside iframes after the requirement for samesite none in Chrome 80. See https://www.imsglobal.org/samesite-cookie-issues-lti-tool-providers for more details

Also updated the default cache to use a file as cache rather than session to prevent having to rely on the default php session cookie