### PR TITLE
Fix several issues when using the library in Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "imsglobal/lti-1p3-tool",
     "type": "library",
     "require": {
-        "fproject/php-jwt": "^4.0",
+        "firebase/php-jwt": "^5.2",
         "phpseclib/phpseclib": "^2.0"
     },
     "autoload": {

--- a/src/lti/Cache.php
+++ b/src/lti/Cache.php
@@ -1,45 +1,9 @@
 <?php
 namespace IMSGlobal\LTI;
 
-class Cache {
-
-    private $cache;
-
-    public function get_launch_data($key) {
-        $this->load_cache();
-        return $this->cache[$key];
-    }
-
-    public function cache_launch_data($key, $jwt_body) {
-        $this->cache[$key] = $jwt_body;
-        $this->save_cache();
-        return $this;
-    }
-
-    public function cache_nonce($nonce) {
-        $this->cache['nonce'][$nonce] = true;
-        $this->save_cache();
-        return $this;
-    }
-
-    public function check_nonce($nonce) {
-        $this->load_cache();
-        if (!isset($this->cache['nonce'][$nonce])) {
-            return false;
-        }
-        return true;
-    }
-
-    private function load_cache() {
-        $cache = file_get_contents(sys_get_temp_dir() . '/lti_cache.txt');
-        if (empty($cache)) {
-            file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', '{}');
-            $this->cache = [];
-        }
-        $this->cache = json_decode($cache, true);
-    }
-
-    private function save_cache() {
-        file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', json_encode($this->cache));
-    }
+interface Cache {
+    public function get_launch_data($key);
+    public function cache_launch_data($key, $jwt_body);
+    public function cache_nonce($nonce);
+    public function check_nonce($nonce);
 }

--- a/src/lti/Cache.php
+++ b/src/lti/Cache.php
@@ -43,4 +43,3 @@ class Cache {
         file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', json_encode($this->cache));
     }
 }
-?>

--- a/src/lti/Cookie.php
+++ b/src/lti/Cookie.php
@@ -1,33 +1,7 @@
 <?php
 namespace IMSGlobal\LTI;
 
-class Cookie {
-    public function get_cookie($name) {
-        if (isset($_COOKIE[$name])) {
-            return $_COOKIE[$name];
-        }
-        // Look for backup cookie if same site is not supported by the user's browser.
-        if (isset($_COOKIE["LEGACY_" . $name])) {
-            return $_COOKIE["LEGACY_" . $name];
-        }
-        return false;
-    }
-
-    public function set_cookie($name, $value, $exp = 3600, $options = []) {
-        $cookie_options = [
-            'expires' => time() + $exp
-        ];
-
-        // SameSite none and secure will be required for tools to work inside iframes
-        $same_site_options = [
-            'samesite' => 'None',
-            'secure' => true
-        ];
-
-        setcookie($name, $value, array_merge($cookie_options, $same_site_options, $options));
-
-        // Set a second fallback cookie in the event that "SameSite" is not supported
-        setcookie("LEGACY_" . $name, $value, array_merge($cookie_options, $options));
-        return $this;
-    }
+interface Cookie {
+    public function get_cookie($name);
+    public function set_cookie($name, $value, $exp = 3600, $options = []);
 }

--- a/src/lti/Cookie.php
+++ b/src/lti/Cookie.php
@@ -31,4 +31,3 @@ class Cookie {
         return $this;
     }
 }
-?>

--- a/src/lti/Database.php
+++ b/src/lti/Database.php
@@ -6,4 +6,3 @@ interface Database {
     public function find_deployment($iss, $deployment_id);
 }
 
-?>

--- a/src/lti/ImsCache.php
+++ b/src/lti/ImsCache.php
@@ -1,0 +1,45 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class ImsCache {
+
+    private $cache;
+
+    public function get_launch_data($key) {
+        $this->load_cache();
+        return $this->cache[$key];
+    }
+
+    public function cache_launch_data($key, $jwt_body) {
+        $this->cache[$key] = $jwt_body;
+        $this->save_cache();
+        return $this;
+    }
+
+    public function cache_nonce($nonce) {
+        $this->cache['nonce'][$nonce] = true;
+        $this->save_cache();
+        return $this;
+    }
+
+    public function check_nonce($nonce) {
+        $this->load_cache();
+        if (!isset($this->cache['nonce'][$nonce])) {
+            return false;
+        }
+        return true;
+    }
+
+    private function load_cache() {
+        $cache = file_get_contents(sys_get_temp_dir() . '/lti_cache.txt');
+        if (empty($cache)) {
+            file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', '{}');
+            $this->cache = [];
+        }
+        $this->cache = json_decode($cache, true);
+    }
+
+    private function save_cache() {
+        file_put_contents(sys_get_temp_dir() . '/lti_cache.txt', json_encode($this->cache));
+    }
+}

--- a/src/lti/ImsCookie.php
+++ b/src/lti/ImsCookie.php
@@ -1,0 +1,33 @@
+<?php
+namespace IMSGlobal\LTI;
+
+class ImsCookie {
+    public function get_cookie($name) {
+        if (isset($_COOKIE[$name])) {
+            return $_COOKIE[$name];
+        }
+        // Look for backup cookie if same site is not supported by the user's browser.
+        if (isset($_COOKIE["LEGACY_" . $name])) {
+            return $_COOKIE["LEGACY_" . $name];
+        }
+        return false;
+    }
+
+    public function set_cookie($name, $value, $exp = 3600, $options = []) {
+        $cookie_options = [
+            'expires' => time() + $exp
+        ];
+
+        // SameSite none and secure will be required for tools to work inside iframes
+        $same_site_options = [
+            'samesite' => 'None',
+            'secure' => true
+        ];
+
+        setcookie($name, $value, array_merge($cookie_options, $same_site_options, $options));
+
+        // Set a second fallback cookie in the event that "SameSite" is not supported
+        setcookie("LEGACY_" . $name, $value, array_merge($cookie_options, $options));
+        return $this;
+    }
+}

--- a/src/lti/LTI_Assignments_Grades_Service.php
+++ b/src/lti/LTI_Assignments_Grades_Service.php
@@ -88,4 +88,3 @@ class LTI_Assignments_Grades_Service {
         return $scores['body'];
     }
 }
-?>

--- a/src/lti/LTI_Assignments_Grades_Service.php
+++ b/src/lti/LTI_Assignments_Grades_Service.php
@@ -12,7 +12,7 @@ class LTI_Assignments_Grades_Service {
     }
 
     public function put_grade(LTI_Grade $grade, LTI_Lineitem $lineitem = null) {
-        if (!in_array("https://purl.imsglobal.org/spec/lti-ags/scope/score", $this->service_data['scope'])) {
+        if (!in_array(LTI_Constants::AGS_SCORE, $this->service_data['scope'])) {
             throw new LTI_Exception('Missing required scope', 1);
         }
         $score_url = '';
@@ -42,7 +42,7 @@ class LTI_Assignments_Grades_Service {
     }
 
     public function find_or_create_lineitem(LTI_Lineitem $new_line_item) {
-        if (!in_array("https://purl.imsglobal.org/spec/lti-ags/scope/lineitem", $this->service_data['scope'])) {
+        if (!in_array(LTI_Constants::AGS_LINEITEM, $this->service_data['scope'])) {
             throw new LTI_Exception('Missing required scope', 1);
         }
         $line_items = $this->service_connector->make_service_request(

--- a/src/lti/LTI_Constants.php
+++ b/src/lti/LTI_Constants.php
@@ -28,15 +28,15 @@ class LTI_Constants
     public const DL_DEEP_LINK_SETTINGS = 'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings';
 
     // LTI NRPS
-    public const NRPS_NAMESROLESPROVISIONINGSERVICE = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
-    public const NRPS_CONTEXT_MEMBERSHIP_READ_ONLY = 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly';
+    public const NRPS_CLAIM_SERVICE = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
+    public const NRPS_SCOPE_MEMBERSHIP_READONLY = 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly';
 
     // LTI AGS
-    public const AGS_ENDPOINT = 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint';
-    public const AGS_LINEITEM = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem';
-    public const AGS_LINEITEM_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly';
-    public const AGS_RESULT_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly';
-    public const AGS_SCORE = 'https://purl.imsglobal.org/spec/lti-ags/scope/score';
+    public const AGS_CLAIM_ENDPOINT = 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint';
+    public const AGS_SCOPE_LINEITEM = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem';
+    public const AGS_SCOPE_LINEITEM_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly';
+    public const AGS_SCOPE_RESULT_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly';
+    public const AGS_SCOPE_SCORE = 'https://purl.imsglobal.org/spec/lti-ags/scope/score';
 
     // User Vocab
     public const SYSTEM_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator';

--- a/src/lti/LTI_Constants.php
+++ b/src/lti/LTI_Constants.php
@@ -22,8 +22,14 @@ class LTI_Constants
     const LIS = 'https://purl.imsglobal.org/spec/lti/claim/lis';
     const CUSTOM = 'https://purl.imsglobal.org/spec/lti/claim/custom';
 
+    // LTI DL
+    const DL_CONTENT_ITEMS = 'https://purl.imsglobal.org/spec/lti-dl/claim/content_items';
+    const DL_DATA = 'https://purl.imsglobal.org/spec/lti-dl/claim/data';
+    const DL_DEEP_LINK_SETTINGS = 'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings';
+
     // LTI NRPS
-    const NRPS = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
+    const NRPS_NAMESROLESPROVISIONINGSERVICE = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
+    const NRPS_CONTEXT_MEMBERSHIP_READ_ONLY = 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly';
 
     // LTI AGS
     const AGS_ENDPOINT = 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint';

--- a/src/lti/LTI_Constants.php
+++ b/src/lti/LTI_Constants.php
@@ -4,74 +4,74 @@ namespace IMSGlobal\LTI;
 
 class LTI_Constants
 {
-    CONST V1_3 = '1.3.0';
+    public const V1_3 = '1.3.0';
 
     // Required message claims
-    const MESSAGE_TYPE = 'https://purl.imsglobal.org/spec/lti/claim/message_type';
-    const VERSION = 'https://purl.imsglobal.org/spec/lti/claim/version';
-    const DEPLOYMENT_ID = 'https://purl.imsglobal.org/spec/lti/claim/deployment_id';
-    const TARGET_LINK_URI = 'https://purl.imsglobal.org/spec/lti/claim/target_link_uri';
-    const RESOURCE_LINK = 'https://purl.imsglobal.org/spec/lti/claim/resource_link';
-    const ROLES = 'https://purl.imsglobal.org/spec/lti/claim/roles';
+    public const MESSAGE_TYPE = 'https://purl.imsglobal.org/spec/lti/claim/message_type';
+    public const VERSION = 'https://purl.imsglobal.org/spec/lti/claim/version';
+    public const DEPLOYMENT_ID = 'https://purl.imsglobal.org/spec/lti/claim/deployment_id';
+    public const TARGET_LINK_URI = 'https://purl.imsglobal.org/spec/lti/claim/target_link_uri';
+    public const RESOURCE_LINK = 'https://purl.imsglobal.org/spec/lti/claim/resource_link';
+    public const ROLES = 'https://purl.imsglobal.org/spec/lti/claim/roles';
 
     // Optional message claims
-    const CONTEXT = 'https://purl.imsglobal.org/spec/lti/claim/context';
-    const TOOL_PLATFORM = 'https://purl.imsglobal.org/spec/lti/claim/tool_platform';
-    const ROLE_SCOPE_MENTOR = 'https://purlimsglobal.org/spec/lti/claim/role_scope_mentor';
-    const LAUNCH_PRESENTATION = 'https://purl.imsglobal.org/spec/lti/claim/launch_presentation';
-    const LIS = 'https://purl.imsglobal.org/spec/lti/claim/lis';
-    const CUSTOM = 'https://purl.imsglobal.org/spec/lti/claim/custom';
+    public const CONTEXT = 'https://purl.imsglobal.org/spec/lti/claim/context';
+    public const TOOL_PLATFORM = 'https://purl.imsglobal.org/spec/lti/claim/tool_platform';
+    public const ROLE_SCOPE_MENTOR = 'https://purlimsglobal.org/spec/lti/claim/role_scope_mentor';
+    public const LAUNCH_PRESENTATION = 'https://purl.imsglobal.org/spec/lti/claim/launch_presentation';
+    public const LIS = 'https://purl.imsglobal.org/spec/lti/claim/lis';
+    public const CUSTOM = 'https://purl.imsglobal.org/spec/lti/claim/custom';
 
     // LTI DL
-    const DL_CONTENT_ITEMS = 'https://purl.imsglobal.org/spec/lti-dl/claim/content_items';
-    const DL_DATA = 'https://purl.imsglobal.org/spec/lti-dl/claim/data';
-    const DL_DEEP_LINK_SETTINGS = 'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings';
+    public const DL_CONTENT_ITEMS = 'https://purl.imsglobal.org/spec/lti-dl/claim/content_items';
+    public const DL_DATA = 'https://purl.imsglobal.org/spec/lti-dl/claim/data';
+    public const DL_DEEP_LINK_SETTINGS = 'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings';
 
     // LTI NRPS
-    const NRPS_NAMESROLESPROVISIONINGSERVICE = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
-    const NRPS_CONTEXT_MEMBERSHIP_READ_ONLY = 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly';
+    public const NRPS_NAMESROLESPROVISIONINGSERVICE = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
+    public const NRPS_CONTEXT_MEMBERSHIP_READ_ONLY = 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly';
 
     // LTI AGS
-    const AGS_ENDPOINT = 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint';
-    const AGS_LINEITEM = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem';
-    const AGS_LINEITEM_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly';
-    const AGS_RESULT_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly';
-    const AGS_SCORE = 'https://purl.imsglobal.org/spec/lti-ags/scope/score';
+    public const AGS_ENDPOINT = 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint';
+    public const AGS_LINEITEM = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem';
+    public const AGS_LINEITEM_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly';
+    public const AGS_RESULT_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly';
+    public const AGS_SCORE = 'https://purl.imsglobal.org/spec/lti-ags/scope/score';
 
     // User Vocab
-    const SYSTEM_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator';
-    const SYSTEM_NONE = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#None';
-    const SYSTEM_ACCOUNTADMIN = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#AccountAdmin';
-    const SYSTEM_CREATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Creator';
-    const SYSTEM_SYSADMIN = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin';
-    const SYSTEM_SYSSUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysSupport';
-    const SYSTEM_USER = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#User';
-    const INSTITUTION_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator';
-    const INSTITUTION_FACULTY = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty';
-    const INSTITUTION_GUEST = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Guest';
-    const INSTITUTION_NONE = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#None';
-    const INSTITUTION_OTHER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Other';
-    const INSTITUTION_STAFF = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff';
-    const INSTITUTION_STUDENT = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student';
-    const INSTITUTION_ALUMNI = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni';
-    const INSTITUTION_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor';
-    const INSTITUTION_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner';
-    const INSTITUTION_MEMBER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Member';
-    const INSTITUTION_MENTOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor';
-    const INSTITUTION_OBSERVER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Observer';
-    const INSTITUTION_PROSPECTIVESTUDENT = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#ProspectiveStudent';
-    const MEMBERSHIP_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator';
-    const MEMBERSHIP_CONTENTDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper';
-    const MEMBERSHIP_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor';
-    const MEMBERSHIP_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner';
-    const MEMBERSHIP_MENTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor';
-    const MEMBERSHIP_MANAGER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Manager';
-    const MEMBERSHIP_MEMBER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Member';
-    const MEMBERSHIP_OFFICER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Officer';
+    public const SYSTEM_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator';
+    public const SYSTEM_NONE = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#None';
+    public const SYSTEM_ACCOUNTADMIN = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#AccountAdmin';
+    public const SYSTEM_CREATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Creator';
+    public const SYSTEM_SYSADMIN = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin';
+    public const SYSTEM_SYSSUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysSupport';
+    public const SYSTEM_USER = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#User';
+    public const INSTITUTION_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator';
+    public const INSTITUTION_FACULTY = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty';
+    public const INSTITUTION_GUEST = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Guest';
+    public const INSTITUTION_NONE = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#None';
+    public const INSTITUTION_OTHER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Other';
+    public const INSTITUTION_STAFF = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff';
+    public const INSTITUTION_STUDENT = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student';
+    public const INSTITUTION_ALUMNI = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni';
+    public const INSTITUTION_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor';
+    public const INSTITUTION_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner';
+    public const INSTITUTION_MEMBER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Member';
+    public const INSTITUTION_MENTOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor';
+    public const INSTITUTION_OBSERVER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Observer';
+    public const INSTITUTION_PROSPECTIVESTUDENT = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#ProspectiveStudent';
+    public const MEMBERSHIP_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator';
+    public const MEMBERSHIP_CONTENTDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper';
+    public const MEMBERSHIP_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor';
+    public const MEMBERSHIP_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner';
+    public const MEMBERSHIP_MENTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor';
+    public const MEMBERSHIP_MANAGER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Manager';
+    public const MEMBERSHIP_MEMBER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Member';
+    public const MEMBERSHIP_OFFICER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Officer';
 
     // Context Vocab
-    const COURSE_TEMPLATE = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate';
-    const COURSE_OFFERING = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering';
-    const COURSE_SECTION = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection';
-    const COURSE_GROUP = 'http://purl.imsglobal.org/vocab/lis/v2/course#Group';
+    public const COURSE_TEMPLATE = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate';
+    public const COURSE_OFFERING = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering';
+    public const COURSE_SECTION = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection';
+    public const COURSE_GROUP = 'http://purl.imsglobal.org/vocab/lis/v2/course#Group';
 }

--- a/src/lti/LTI_Constants.php
+++ b/src/lti/LTI_Constants.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace IMSGlobal\LTI;
+
+class LTI_Constants
+{
+    CONST V1_3 = '1.3.0';
+
+    // Required message claims
+    const MESSAGE_TYPE = 'https://purl.imsglobal.org/spec/lti/claim/message_type';
+    const VERSION = 'https://purl.imsglobal.org/spec/lti/claim/version';
+    const DEPLOYMENT_ID = 'https://purl.imsglobal.org/spec/lti/claim/deployment_id';
+    const TARGET_LINK_URI = 'https://purl.imsglobal.org/spec/lti/claim/target_link_uri';
+    const RESOURCE_LINK = 'https://purl.imsglobal.org/spec/lti/claim/resource_link';
+    const ROLES = 'https://purl.imsglobal.org/spec/lti/claim/roles';
+
+    // Optional message claims
+    const CONTEXT = 'https://purl.imsglobal.org/spec/lti/claim/context';
+    const TOOL_PLATFORM = 'https://purl.imsglobal.org/spec/lti/claim/tool_platform';
+    const ROLE_SCOPE_MENTOR = 'https://purlimsglobal.org/spec/lti/claim/role_scope_mentor';
+    const LAUNCH_PRESENTATION = 'https://purl.imsglobal.org/spec/lti/claim/launch_presentation';
+    const LIS = 'https://purl.imsglobal.org/spec/lti/claim/lis';
+    const CUSTOM = 'https://purl.imsglobal.org/spec/lti/claim/custom';
+
+    // LTI NRPS
+    const NRPS = 'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice';
+
+    // LTI AGS
+    const AGS_ENDPOINT = 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint';
+    const AGS_LINEITEM = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem';
+    const AGS_LINEITEM_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly';
+    const AGS_RESULT_READONLY = 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly';
+    const AGS_SCORE = 'https://purl.imsglobal.org/spec/lti-ags/scope/score';
+
+    // User Vocab
+    const SYSTEM_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator';
+    const SYSTEM_NONE = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#None';
+    const SYSTEM_ACCOUNTADMIN = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#AccountAdmin';
+    const SYSTEM_CREATOR = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Creator';
+    const SYSTEM_SYSADMIN = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin';
+    const SYSTEM_SYSSUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysSupport';
+    const SYSTEM_USER = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#User';
+    const INSTITUTION_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator';
+    const INSTITUTION_FACULTY = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Faculty';
+    const INSTITUTION_GUEST = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Guest';
+    const INSTITUTION_NONE = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#None';
+    const INSTITUTION_OTHER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Other';
+    const INSTITUTION_STAFF = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff';
+    const INSTITUTION_STUDENT = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student';
+    const INSTITUTION_ALUMNI = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni';
+    const INSTITUTION_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor';
+    const INSTITUTION_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner';
+    const INSTITUTION_MEMBER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Member';
+    const INSTITUTION_MENTOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor';
+    const INSTITUTION_OBSERVER = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Observer';
+    const INSTITUTION_PROSPECTIVESTUDENT = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#ProspectiveStudent';
+    const MEMBERSHIP_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator';
+    const MEMBERSHIP_CONTENTDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper';
+    const MEMBERSHIP_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor';
+    const MEMBERSHIP_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner';
+    const MEMBERSHIP_MENTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor';
+    const MEMBERSHIP_MANAGER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Manager';
+    const MEMBERSHIP_MEMBER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Member';
+    const MEMBERSHIP_OFFICER = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Officer';
+
+    // Context Vocab
+    const COURSE_TEMPLATE = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate';
+    const COURSE_OFFERING = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering';
+    const COURSE_SECTION = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection';
+    const COURSE_GROUP = 'http://purl.imsglobal.org/vocab/lis/v2/course#Group';
+}

--- a/src/lti/LTI_Deep_Link.php
+++ b/src/lti/LTI_Deep_Link.php
@@ -21,9 +21,9 @@ class LTI_Deep_Link {
             "exp" => time() + 600,
             "iat" => time(),
             "nonce" => 'nonce' . hash('sha256', random_bytes(64)),
-            "https://purl.imsglobal.org/spec/lti/claim/deployment_id" => $this->deployment_id,
-            "https://purl.imsglobal.org/spec/lti/claim/message_type" => "LtiDeepLinkingResponse",
-            "https://purl.imsglobal.org/spec/lti/claim/version" => "1.3.0",
+            LTI_Constants::DEPLOYMENT_ID => $this->deployment_id,
+            LTI_Constants::MESSAGE_TYPE => "LtiDeepLinkingResponse",
+            LTI_Constants::VERSION => LTI_Constants::V1_3,
             "https://purl.imsglobal.org/spec/lti-dl/claim/content_items" => array_map(function($resource) { return $resource->to_array(); }, $resources),
             "https://purl.imsglobal.org/spec/lti-dl/claim/data" => $this->deep_link_settings['data'],
         ];

--- a/src/lti/LTI_Deep_Link.php
+++ b/src/lti/LTI_Deep_Link.php
@@ -43,4 +43,3 @@ class LTI_Deep_Link {
         <?php
     }
 }
-?>

--- a/src/lti/LTI_Deep_Link.php
+++ b/src/lti/LTI_Deep_Link.php
@@ -24,8 +24,8 @@ class LTI_Deep_Link {
             LTI_Constants::DEPLOYMENT_ID => $this->deployment_id,
             LTI_Constants::MESSAGE_TYPE => "LtiDeepLinkingResponse",
             LTI_Constants::VERSION => LTI_Constants::V1_3,
-            "https://purl.imsglobal.org/spec/lti-dl/claim/content_items" => array_map(function($resource) { return $resource->to_array(); }, $resources),
-            "https://purl.imsglobal.org/spec/lti-dl/claim/data" => $this->deep_link_settings['data'],
+            LTI_Constants::DL_CONTENT_ITEMS => array_map(function($resource) { return $resource->to_array(); }, $resources),
+            LTI_Constants::DL_DATA => $this->deep_link_settings['data'],
         ];
         return JWT::encode($message_jwt, $this->registration->get_tool_private_key(), 'RS256', $this->registration->get_kid());
     }

--- a/src/lti/LTI_Deep_Link_Resource.php
+++ b/src/lti/LTI_Deep_Link_Resource.php
@@ -87,4 +87,4 @@ class LTI_Deep_Link_Resource {
         return $resource;
     }
 }
-?>
+

--- a/src/lti/LTI_Deployment.php
+++ b/src/lti/LTI_Deployment.php
@@ -20,4 +20,3 @@ class LTI_Deployment {
 
 }
 
-?>

--- a/src/lti/LTI_Exception.php
+++ b/src/lti/LTI_Exception.php
@@ -4,4 +4,3 @@ namespace IMSGlobal\LTI;
 class LTI_Exception extends \Exception {
 
 }
-?>

--- a/src/lti/LTI_Grade.php
+++ b/src/lti/LTI_Grade.php
@@ -81,4 +81,3 @@ class LTI_Grade {
         ]));
     }
 }
-?>

--- a/src/lti/LTI_Lineitem.php
+++ b/src/lti/LTI_Lineitem.php
@@ -105,4 +105,3 @@ class LTI_Lineitem {
         ]));
     }
 }
-?>

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -352,4 +352,4 @@ class LTI_Message_Launch {
 
     }
 }
-?>
+

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -3,6 +3,7 @@ namespace IMSGlobal\LTI;
 
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
+use Firebase\JWT\ExpiredException;
 
 JWT::$leeway = 5;
 
@@ -279,7 +280,7 @@ class LTI_Message_Launch {
         // Validate JWT signature
         try {
             JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));
-        } catch(\Exception $e) {
+        } catch(ExpiredException $e) {
             var_dump($e);
             // Error validating signature.
             throw new LTI_Exception("Invalid signature on id_token", 1);

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -245,6 +245,9 @@ class LTI_Message_Launch {
     }
 
     private function validate_nonce() {
+        if (!isset($this->jwt['body']['nonce'])) {
+            throw new LTI_Exception("Missing Nonce");
+        }
         if (!$this->cache->check_nonce($this->jwt['body']['nonce'])) {
             //throw new LTI_Exception("Invalid Nonce");
         }

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -137,7 +137,7 @@ class LTI_Message_Launch {
     public function get_deep_link() {
         return new LTI_Deep_Link(
             $this->registration,
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],
+            $this->jwt['body'][LTI_Constants::DEPLOYMENT_ID],
             $this->jwt['body']['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']);
     }
 
@@ -147,7 +147,7 @@ class LTI_Message_Launch {
      * @return boolean  Returns true if the current launch is a deep linking launch.
      */
     public function is_deep_link_launch() {
-        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiDeepLinkingRequest';
+        return $this->jwt['body'][LTI_Constants::MESSAGE_TYPE] === 'LtiDeepLinkingRequest';
     }
 
     /**
@@ -156,7 +156,7 @@ class LTI_Message_Launch {
      * @return boolean  Returns true if the current launch is a resource launch.
      */
     public function is_resource_launch() {
-        return $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiResourceLinkRequest';
+        return $this->jwt['body'][LTI_Constants::MESSAGE_TYPE] === 'LtiResourceLinkRequest';
     }
 
     /**
@@ -289,12 +289,12 @@ class LTI_Message_Launch {
     }
 
     private function validate_deployment() {
-        if (!isset($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'])) {
+        if (!isset($this->jwt['body'][LTI_Constants::DEPLOYMENT_ID])) {
             throw new LTI_Exception("No deployment ID was specified", 1);
         }
 
         // Find deployment.
-        $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id']);
+        $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body'][LTI_Constants::DEPLOYMENT_ID]);
 
         if (empty($deployment)) {
             // deployment not recognized.
@@ -305,7 +305,7 @@ class LTI_Message_Launch {
     }
 
     private function validate_message() {
-        if (empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/message_type'])) {
+        if (empty($this->jwt['body'][LTI_Constants::MESSAGE_TYPE])) {
             // Unable to identify message type.
             throw new LTI_Exception("Invalid message type", 1);
         }

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -29,12 +29,12 @@ class LTI_Message_Launch {
         $this->launch_id = uniqid("lti1p3_launch_", true);
 
         if ($cache === null) {
-            $cache = new Cache();
+            $cache = new ImsCache();
         }
         $this->cache = $cache;
 
         if ($cookie === null) {
-            $cookie = new Cookie();
+            $cookie = new ImsCookie();
         }
         $this->cookie = $cookie;
     }

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -281,7 +281,6 @@ class LTI_Message_Launch {
         try {
             JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));
         } catch(ExpiredException $e) {
-            var_dump($e);
             // Error validating signature.
             throw new LTI_Exception("Invalid signature on id_token", 1);
         }

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -191,7 +191,11 @@ class LTI_Message_Launch {
         foreach ($public_key_set['keys'] as $key) {
             if ($key['kid'] == $this->jwt['header']['kid']) {
                 try {
-                    return openssl_pkey_get_details(JWK::parseKey($key));
+                    return openssl_pkey_get_details(
+                        JWK::parseKeySet([
+                            'keys' => [$key]
+                        ])[$key['kid']]
+                    );
                 } catch(\Exception $e) {
                     return false;
                 }
@@ -265,6 +269,10 @@ class LTI_Message_Launch {
     }
 
     private function validate_jwt_signature() {
+        if (!isset($this->jwt['header']['kid'])) {
+            throw new LTI_Exception("No KID specified in the JWT Header");
+        }
+
         // Fetch public key.
         $public_key = $this->get_public_key();
 

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -289,6 +289,10 @@ class LTI_Message_Launch {
     }
 
     private function validate_deployment() {
+        if (!isset($this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id'])) {
+            throw new LTI_Exception("No deployment ID was specified", 1);
+        }
+
         // Find deployment.
         $deployment = $this->db->find_deployment($this->jwt['body']['iss'], $this->jwt['body']['https://purl.imsglobal.org/spec/lti/claim/deployment_id']);
 

--- a/src/lti/LTI_Message_Launch.php
+++ b/src/lti/LTI_Message_Launch.php
@@ -95,7 +95,7 @@ class LTI_Message_Launch {
      * @return boolean  Returns a boolean indicating the availability of names and roles.
      */
     public function has_nrps() {
-        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']['context_memberships_url']);
+        return !empty($this->jwt['body'][LTI_Constants::NRPS_NAMESROLESPROVISIONINGSERVICE]['context_memberships_url']);
     }
 
     /**
@@ -106,7 +106,7 @@ class LTI_Message_Launch {
     public function get_nrps() {
         return new LTI_Names_Roles_Provisioning_Service(
             new LTI_Service_Connector($this->registration),
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']);
+            $this->jwt['body'][LTI_Constants::NRPS_NAMESROLESPROVISIONINGSERVICE]);
     }
 
     /**
@@ -115,7 +115,7 @@ class LTI_Message_Launch {
      * @return boolean  Returns a boolean indicating the availability of assignments and grades.
      */
     public function has_ags() {
-        return !empty($this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);
+        return !empty($this->jwt['body'][LTI_Constants::AGS_ENDPOINT]);
     }
 
     /**
@@ -126,7 +126,7 @@ class LTI_Message_Launch {
     public function get_ags() {
         return new LTI_Assignments_Grades_Service(
             new LTI_Service_Connector($this->registration),
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']);
+            $this->jwt['body'][LTI_Constants::AGS_ENDPOINT]);
     }
 
     /**
@@ -138,7 +138,7 @@ class LTI_Message_Launch {
         return new LTI_Deep_Link(
             $this->registration,
             $this->jwt['body'][LTI_Constants::DEPLOYMENT_ID],
-            $this->jwt['body']['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings']);
+            $this->jwt['body'][LTI_Constants::DL_DEEP_LINK_SETTINGS]);
     }
 
     /**

--- a/src/lti/LTI_Names_Roles_Provisioning_Service.php
+++ b/src/lti/LTI_Names_Roles_Provisioning_Service.php
@@ -41,4 +41,3 @@ class LTI_Names_Roles_Provisioning_Service {
 
     }
 }
-?>

--- a/src/lti/LTI_Names_Roles_Provisioning_Service.php
+++ b/src/lti/LTI_Names_Roles_Provisioning_Service.php
@@ -19,7 +19,7 @@ class LTI_Names_Roles_Provisioning_Service {
 
         while ($next_page) {
             $page = $this->service_connector->make_service_request(
-                ['https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly'],
+                [LTI_Constants::NRPS_CONTEXT_MEMBERSHIP_READ_ONLY],
                 'GET',
                 $next_page,
                 null,

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -3,6 +3,8 @@ namespace IMSGlobal\LTI;
 
 class LTI_OIDC_Login {
 
+    public const COOKIE_PREFIX = 'lti1p3_';
+
     private $db;
     private $cache;
     private $cookie;
@@ -62,7 +64,7 @@ class LTI_OIDC_Login {
         // Generate State.
         // Set cookie (short lived)
         $state = str_replace('.', '_', uniqid('state-', true));
-        $this->cookie->set_cookie("lti1p3_$state", $state, 60);
+        $this->cookie->set_cookie(static::COOKIE_PREFIX.$state, $state, 60);
 
         // Generate Nonce.
         $nonce = uniqid('nonce-', true);

--- a/src/lti/LTI_OIDC_Login.php
+++ b/src/lti/LTI_OIDC_Login.php
@@ -17,12 +17,12 @@ class LTI_OIDC_Login {
     function __construct(Database $database, Cache $cache = null, Cookie $cookie = null) {
         $this->db = $database;
         if ($cache === null) {
-            $cache = new Cache();
+            $cache = new ImsCache();
         }
         $this->cache = $cache;
 
         if ($cookie === null) {
-            $cookie = new Cookie();
+            $cookie = new ImsCookie();
         }
         $this->cookie = $cookie;
     }

--- a/src/lti/LTI_Registration.php
+++ b/src/lti/LTI_Registration.php
@@ -90,4 +90,3 @@ class LTI_Registration {
 
 }
 
-?>

--- a/src/lti/LTI_Service_Connector.php
+++ b/src/lti/LTI_Service_Connector.php
@@ -87,4 +87,3 @@ class LTI_Service_Connector {
         ];
     }
 }
-?>

--- a/src/lti/Message_Validator.php
+++ b/src/lti/Message_Validator.php
@@ -5,4 +5,3 @@ interface Message_Validator {
     public function validate($jwt_body);
     public function can_validate($jwt_body);
 }
-?>

--- a/src/lti/OIDC_Exception.php
+++ b/src/lti/OIDC_Exception.php
@@ -4,4 +4,3 @@ namespace IMSGlobal\LTI;
 class OIDC_Exception extends \Exception {
 
 }
-?>

--- a/src/lti/Redirect.php
+++ b/src/lti/Redirect.php
@@ -19,7 +19,7 @@ class Redirect {
 
     public function do_hybrid_redirect(Cookie $cookie = null) {
         if ($cookie == null) {
-            $cookie = new Cookie();
+            $cookie = new ImsCookie();
         }
         if (!empty($cookie->get_cookie(self::$CAN_302_COOKIE))) {
             return $this->do_redirect();

--- a/src/lti/Redirect.php
+++ b/src/lti/Redirect.php
@@ -79,5 +79,3 @@ class Redirect {
     }
 
 }
-
-?>

--- a/src/lti/lti.php
+++ b/src/lti/lti.php
@@ -5,4 +5,3 @@ foreach (glob(__DIR__ . "/*.php") as $filename) {
 }
 define("TOOL_HOST", ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?: $_SERVER['REQUEST_SCHEME']) . '://' . $_SERVER['HTTP_HOST']);
 Firebase\JWT\JWT::$leeway = 5;
-?>

--- a/src/lti/message_validators/deep_link_message_validator.php
+++ b/src/lti/message_validators/deep_link_message_validator.php
@@ -33,4 +33,3 @@ class Deep_Link_Message_Validator implements Message_Validator {
         return true;
     }
 }
-?>

--- a/src/lti/message_validators/deep_link_message_validator.php
+++ b/src/lti/message_validators/deep_link_message_validator.php
@@ -16,10 +16,10 @@ class Deep_Link_Message_Validator implements Message_Validator {
         if (!isset($jwt_body[LTI_Constants::ROLES])) {
             throw new LTI_Exception('Missing Roles Claim');
         }
-        if (empty($jwt_body['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'])) {
+        if (empty($jwt_body[LTI_Constants::DL_DEEP_LINK_SETTINGS])) {
             throw new LTI_Exception('Missing Deep Linking Settings');
         }
-        $deep_link_settings = $jwt_body['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'];
+        $deep_link_settings = $jwt_body[LTI_Constants::DL_DEEP_LINK_SETTINGS];
         if (empty($deep_link_settings['deep_link_return_url'])) {
             throw new LTI_Exception('Missing Deep Linking Return URL');
         }

--- a/src/lti/message_validators/deep_link_message_validator.php
+++ b/src/lti/message_validators/deep_link_message_validator.php
@@ -3,17 +3,17 @@ namespace IMSGlobal\LTI;
 
 class Deep_Link_Message_Validator implements Message_Validator {
     public function can_validate($jwt_body) {
-        return $jwt_body['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiDeepLinkingRequest';
+        return $jwt_body[LTI_Constants::MESSAGE_TYPE] === 'LtiDeepLinkingRequest';
     }
 
     public function validate($jwt_body) {
         if (empty($jwt_body['sub'])) {
             throw new LTI_Exception('Must have a user (sub)');
         }
-        if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
+        if ($jwt_body[LTI_Constants::VERSION] !== LTI_Constants::V1_3) {
             throw new LTI_Exception('Incorrect version, expected 1.3.0');
         }
-        if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
+        if (!isset($jwt_body[LTI_Constants::ROLES])) {
             throw new LTI_Exception('Missing Roles Claim');
         }
         if (empty($jwt_body['https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'])) {

--- a/src/lti/message_validators/resource_message_validator.php
+++ b/src/lti/message_validators/resource_message_validator.php
@@ -3,20 +3,20 @@ namespace IMSGlobal\LTI;
 
 class Resource_Message_Validator implements Message_Validator {
     public function can_validate($jwt_body) {
-        return $jwt_body['https://purl.imsglobal.org/spec/lti/claim/message_type'] === 'LtiResourceLinkRequest';
+        return $jwt_body[LTI_Constants::MESSAGE_TYPE] === 'LtiResourceLinkRequest';
     }
 
     public function validate($jwt_body) {
         if (empty($jwt_body['sub'])) {
             throw new LTI_Exception('Must have a user (sub)');
         }
-        if ($jwt_body['https://purl.imsglobal.org/spec/lti/claim/version'] !== '1.3.0') {
+        if ($jwt_body[LTI_Constants::VERSION] !== LTI_Constants::V1_3) {
             throw new LTI_Exception('Incorrect version, expected 1.3.0');
         }
-        if (!isset($jwt_body['https://purl.imsglobal.org/spec/lti/claim/roles'])) {
+        if (!isset($jwt_body[LTI_Constants::ROLES])) {
             throw new LTI_Exception('Missing Roles Claim');
         }
-        if (empty($jwt_body['https://purl.imsglobal.org/spec/lti/claim/resource_link']['id'])) {
+        if (empty($jwt_body[LTI_Constants::RESOURCE_LINK]['id'])) {
             throw new LTI_Exception('Missing Resource Link Id');
         }
 

--- a/src/lti/message_validators/resource_message_validator.php
+++ b/src/lti/message_validators/resource_message_validator.php
@@ -10,6 +10,9 @@ class Resource_Message_Validator implements Message_Validator {
         if (empty($jwt_body['sub'])) {
             throw new LTI_Exception('Must have a user (sub)');
         }
+        if (!isset($jwt_body[LTI_Constants::VERSION])) {
+            throw new LTI_Exception('Missing LTI Version');
+        }
         if ($jwt_body[LTI_Constants::VERSION] !== LTI_Constants::V1_3) {
             throw new LTI_Exception('Incorrect version, expected 1.3.0');
         }

--- a/src/lti/message_validators/resource_message_validator.php
+++ b/src/lti/message_validators/resource_message_validator.php
@@ -23,4 +23,3 @@ class Resource_Message_Validator implements Message_Validator {
         return true;
     }
 }
-?>


### PR DESCRIPTION
This PR addresses numerous issues with the library:

- The documentation for the Cookie and Cache objects indicates that they are interfaces, when in fact they implementations. The converts them to interfaces and builds out separate implementations for them.
- Removes a number of `?>` tags per PSR-2 2.2
- Create a class for launch-related constants and removes magic strings.
- Fixes several issues with `LTI_Launch_message::validate_jwt_signature()` to allow these failures to be properly handled per the LTI 1.3 certification process (specifically, no `kid` specified, and expired jwt token)
- Throws an exception when no Deployment ID is specified
- Exposes the cookie prefix so the cookie can be referenced outside of the context of this library without using magic strings

This PR is dependent on EricTendian's PR: https://github.com/IMSGlobal/lti-1-3-php-library/pull/44