### PR TITLE
Fix regexp in the LTI_Names_Roles_Provisioning_Service

### DIFF
--- a/src/lti/LTI_Names_Roles_Provisioning_Service.php
+++ b/src/lti/LTI_Names_Roles_Provisioning_Service.php
@@ -31,7 +31,7 @@ class LTI_Names_Roles_Provisioning_Service {
 
             $next_page = false;
             foreach($page['headers'] as $header) {
-                if (preg_match("/^Link:.*<([^>])>; ?rel=\"next\"/i", $header, $matches)) {
+                if (preg_match("/^Link:.*<([^>]*)>; ?rel=\"next\"/i", $header, $matches)) {
                     $next_page = $matches[1];
                     break;
                 }


### PR DESCRIPTION
hi @MartinLenord .

Looks like there is mistake in your regexp. You forgot `*` symbol