### PR TITLE
Allow LineItem to be loaded from a local cache

### DIFF
--- a/src/lti/LTI_Assignments_Grades_Service.php
+++ b/src/lti/LTI_Assignments_Grades_Service.php
@@ -19,6 +19,8 @@ class LTI_Assignments_Grades_Service {
         if ($lineitem !== null && empty($lineitem->get_id())) {
             $lineitem = $this->find_or_create_lineitem($lineitem);
             $score_url = $lineitem->get_id();
+        } else if($lineitem !== null && !empty($lineitem->get_id())) {
+            $score_url = $lineitem->get_id();
         } else if ($lineitem === null && !empty($this->service_data['lineitem'])) {
             $score_url = $this->service_data['lineitem'] ;
         } else {


### PR DESCRIPTION
Allow a fully formed lineitem to be passed into put_grade, preventing round trip to server when we already know the score url. Discussed in #56 