### PR TITLE
Support canvas submission review

### DIFF
--- a/src/lti/LTI_Assignments_Grades_Service.php
+++ b/src/lti/LTI_Assignments_Grades_Service.php
@@ -19,6 +19,8 @@ class LTI_Assignments_Grades_Service {
         if ($lineitem !== null && empty($lineitem->get_id())) {
             $lineitem = $this->find_or_create_lineitem($lineitem);
             $score_url = $lineitem->get_id();
+        } else if($lineitem !== null && !empty($lineitem->get_id())) {
+            $score_url = $lineitem->get_id();
         } else if ($lineitem === null && !empty($this->service_data['lineitem'])) {
             $score_url = $this->service_data['lineitem'] ;
         } else {

--- a/src/lti/LTI_Grade.php
+++ b/src/lti/LTI_Grade.php
@@ -10,6 +10,7 @@ class LTI_Grade {
     private $timestamp;
     private $user_id;
     private $submission_review;
+    private $custom = [];
 
     /**
      * Static function to allow for method chaining without having to assign to a variable first.
@@ -90,8 +91,17 @@ class LTI_Grade {
         return $this;
     }
 
+    public function set_custom(array $value) {
+        $this->custom = $value;
+        return $this;
+    }
+
+    public function get_custom():array {
+        return $this->custom;
+    }
+
     public function __toString() {
-        return json_encode(array_filter([
+        return json_encode(array_merge(array_filter([
             "scoreGiven" => 0 + $this->score_given,
             "scoreMaximum" => 0 + $this->score_maximum,
             "comment" => $this->comment,
@@ -100,7 +110,7 @@ class LTI_Grade {
             "timestamp" => $this->timestamp,
             "userId" => $this->user_id,
             "submissionReview" => $this->submission_review,
-        ]));
+        ]), $this->custom));
     }
 }
 ?>


### PR DESCRIPTION
Adds a custom property on LTI_Grade, which can be set to an array. This will be merged with the other values during submission.

This allows for the tool to submit a grade using the Canvas "https://canvas.instructure.com/lti/submission" extension. IE:

```
$score = \IMSGlobal\LTI\LTI_Grade::new()
    ->set_score_given(1)
    ->set_score_maximum(1)
    ->set_timestamp(date(\DateTime::ISO8601))
    ->set_activity_progress('Submitted')
    ->set_grading_progress('FullyGraded')
    ->set_user_id($userId);
$canvasFeedback = ["https://canvas.instructure.com/lti/submission" => ["submission_type"=>"online_url", "submission_data"=>Helpers::generateHashedURL($response)]];
$score->set_custom($canvasFeedback);
```