### PR TITLE
Make $custom_params a null object by default

### DIFF
--- a/src/lti/LTI_Deep_Link_Resource.php
+++ b/src/lti/LTI_Deep_Link_Resource.php
@@ -7,7 +7,7 @@ class LTI_Deep_Link_Resource {
     private $title;
     private $url;
     private $lineitem;
-    private $custom_params = [];
+    private $custom_params = (object) null;
     private $target = 'iframe';
 
     public static function new() {


### PR DESCRIPTION
Currently $custom_params is an empty array by default which also gets serialized into an empty array effectively making the LTI Request non-compliant with the standard. When integrating our tool into a platform this lead into a crash on the platform side because they were expecting an object.

I suggest changing it to a null object by default instead so it gets serialized into a json object.